### PR TITLE
参数缺失逗号

### DIFF
--- a/lib/dpapi.rb
+++ b/lib/dpapi.rb
@@ -5,13 +5,14 @@ require 'ffi'
 # struct & function definitions cribbed from...
 # http://msdn.microsoft.com/en-us/library/ms995355.aspx
 
-module DPAPI
+module DpApi
   extend FFI::Library
   ffi_lib 'crypt32'
+  class EncryptError < StandardError;
+  end
+  class DecryptError < StandardError;
+  end
 
-  class EncryptError < StandardError; end
-  class DecryptError < StandardError; end
-  
 =begin
 typedef struct _CRYPTOAPI_BLOB {
   DWORD cbData;
@@ -22,16 +23,16 @@ typedef struct _CRYPTOAPI_BLOB {
     layout :cbData, :uint32,
            :pbData, :pointer
 
-    def initialize blob=nil
-      super nil
+    def initialize(blob=nil)
+      super()
       self.data = blob unless blob.nil?
     end
-    
+
     def data
       self[:pbData].get_bytes(0, self[:cbData])
     end
 
-    def data= blob
+    def data= (blob)
       self[:pbData] = FFI::MemoryPointer.from_string blob
       self[:cbData] = blob.bytesize
     end
@@ -46,7 +47,7 @@ typedef struct _CRYPTOAPI_BLOB {
   AUDIT = 0x10
   NO_RECOVERY = 0x20
   VERIFY_PROTECTION = 0x40
-  
+
 =begin
 BOOL WINAPI CryptProtectData(
   _In_      DATA_BLOB *pDataIn,
@@ -58,26 +59,25 @@ BOOL WINAPI CryptProtectData(
   _Out_     DATA_BLOB *pDataOut
 );
 =end
-  
+
   attach_function :CryptProtectData,
-    [:pointer, :string, :pointer, :pointer, :pointer, :uint32, :pointer],
-    :int32
+                  [:pointer, :string, :pointer, :pointer, :pointer, :uint32, :pointer],
+                  :int32
 
-  def encrypt plaintext, entropy=nil, flags = [], desc=nil
+  def encrypt (plaintext, entropy=nil, flags = [], desc=nil)
     ciphertext_blob = DataBlob.new
+    CryptProtectData(
+        DataBlob.new(plaintext),
+        desc, entropy.nil? ? nil : DataBlob.new(entropy),
+        nil,
+        nil,
+        flags.reduce(0, :|),
+        ciphertext_blob
+    ) or raise EncryptError
 
-    CryptProtectData(DataBlob.new plaintext,
-                     desc,
-                     entropy.nil? ? nil : DataBlob.new(entropy),
-                     nil,
-                     nil,
-                     flags.reduce(0, :|)
-                     ciphertext_blob) or
-      raise EncryptErorr
-    
     ciphertext_blob.data
   end
-  
+
 =begin
 BOOL WINAPI CryptUnprotectData(
   _In_        DATA_BLOB *pDataIn,
@@ -90,25 +90,25 @@ BOOL WINAPI CryptUnprotectData(
 );    
 =end
   attach_function :CryptUnprotectData,
-    [:pointer, :pointer, :pointer, :pointer, :pointer, :uint32, :pointer],
-    :int32
+                  [:pointer, :pointer, :pointer, :pointer, :pointer, :uint32, :pointer],
+                  :int32
 
-  def decrypt ciphertext, entropy=nil, flags=[]
-    plaintext_blob  = DataBlob.new
+  def decrypt (ciphertext, entropy=nil, flags=[])
+    plaintext_blob = DataBlob.new
     desc = FFI::MemoryPointer.new(:pointer, 256)
 
-    CryptUnprotectData(DataBlob.new ciphertext,
-                       desc,
-                       DataBlob.new entropy,
-                       nil,
-                       nil,
-                       flags.reduce(0, :|),
-                       plaintext_blob) or
-      raise DecryptError
-    
+    CryptUnprotectData(
+        DataBlob.new(ciphertext),
+        desc,
+        entropy.nil? ? nil : DataBlob.new(entropy),
+        nil,
+        nil,
+        flags.reduce(0, :|),
+        plaintext_blob
+    ) or raise DecryptError
     [plaintext_blob.data,
      desc.read_pointer.nil? ? nil : desc.read_pointer.read_string
     ]
   end
-  
+
 end


### PR DESCRIPTION
重命名模块名，修复参数缺失逗号导致无法运行的bug
